### PR TITLE
feat: Add Gemini Live Interaction page

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -70,3 +70,7 @@ typing-inspection==0.4.0
 tzdata==2025.2
 urllib3==2.4.0
 youtube-transcript-api==1.0.3
+google-genai
+opencv-python
+pyaudio
+mss


### PR DESCRIPTION
I've implemented a new "Gemini Live Interaction" page in the Streamlit application.

This feature allows you to interact with the Gemini Pro model (`models/gemini-2.5-flash-preview-native-audio-dialog`) via text input. The application streams text responses from Gemini and plays back its audio responses using the configured "Zephyr" voice.

Key changes include:
- Added `gemini_live_page()` to `app.py` with UI for chat and audio playback.
- Integrated `google.genai` SDK's `client.aio.live.connect()` for real-time communication with the Gemini API.
- Handled streaming text and playback of PCM audio data from the API.
- Added `google-genai`, `opencv-python`, `pyaudio`, `mss` to `requirements.txt`.
- Configured `GEMINI_API_KEY` loading from Streamlit secrets.
- Implemented error handling and server-side logging for robustness.
- Added placeholder UI for future mode selections (Camera, Screen).